### PR TITLE
Set percentage width of two sections in error panel

### DIFF
--- a/index.html
+++ b/index.html
@@ -151,14 +151,14 @@
   </p>
   </div>
   <div ng-if="displayError.visible" class="detailsPanel">
-    <div style="display: inline-block">
+    <div style="display: inline-block; max-width: 50%">
       <div><b>Test</b> : {{ displayError.test }}</div>
       <div><b>Subtest</b> : {{ displayError.subtest }}</div>
       <div><b>Expected</b> : <span class="{{ displayError.expected}}">{{ displayError.expected }}</span>
       <b>Got</b> : <span class="{{ displayError.status}}">{{ displayError.status }}</span></div>
       <div><p id="message"><b>Message</b> : {{ displayError.error }}</p></div>
     </div>
-    <div style="display: inline-block; vertical-align: top; margin-left: 20px;">
+    <div style="display: inline-block; vertical-align: top; margin-left: 20px; width: 45%">
         <b style="vertical-align: top">Comments :</b>
         <textarea ng-model="displayError.commentBox" ng-trim="false" cols="40" rows="3"
           ng-focus="startCommentSaveTrigger()"


### PR DESCRIPTION
Fix second part of #109, ie comment not visible.

The error was because the comment box was moving to the next "line", i.e. below the error data block when its width exceeded a certain amount and hence was not visible.

Fixed it by defining a max-width for error data section, and percentage width for comment section.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/wptview/113)

<!-- Reviewable:end -->
