### PR TITLE
Scroll to all results when error panel open

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
 <link rel=stylesheet href="wptview.css">
 <div id="wptview" ng-app="wptview" ng-controller="wptviewController" ng-cloak>
 
-  <span us-spinner="{radius: 20, length: 15}" spinner-on="busy"/>
+    <span us-spinner="{radius: 20, length: 15}" spinner-on="busy"></span>
 
   <div ng-click="displayError.visible = false;" class="page">
   <h1>Test Results Viewer</h1>

--- a/wptview.css
+++ b/wptview.css
@@ -1,14 +1,28 @@
-:root {
+body {
     font-family: "Fira Sans", "DejaVu Sans", "Bitstream Vera Sans", "Sans";
     font-size: 14px;
     padding: 0;
     margin: 0;
     background-color: #f8f8f8;
+    height: 100vh;
+}
+
+#wptview {
+    display: flex;
+    flex-direction: column;
+    height: 100vh;
+    overflow: hidden;
 }
 
 .page {
+    position: relative;
     display: inline-block;
-    width: 100%;
+    width: 97vw;
+    flex: 1;
+    overflow-y: scroll;
+
+    padding-left: 1.5vw;
+    padding-right: 1.5vw;
 }
 
 h1 {
@@ -22,20 +36,15 @@ h1 {
 #message {
     font-family: "Fira Sans Mono", "DejaVu Sans Mono", "Bitstream Vera Sans Mono", "Monospace";
 }
+
 .detailsPanel {
-    position: fixed;
-    bottom: 0px;
-    left: 0px;
+    position: relative;
     height: 15vh;
-    width: 100%;
     background-color: #FFFFFF;
     border-top: solid black;
     padding: 1%;
-}
 
-#wptview {
-    padding-left: 16px;
-    padding-right: 16px;
+    flex: none;
 }
 
 #runsData {


### PR DESCRIPTION
Fix #115

Made results container (`.page`) scrollable instead of the global container. (`#wptview`).
Also make `.page` fill availabe height using `flex` properties of CSS.

You should test this with firefox, it might give problems due to the use of `flex`. I've tested on chrome, works fine.

These problems will get fixed together if we start with #105. It will involve making the HTML code much better, less hacky.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/wptview/117)

<!-- Reviewable:end -->
