### PR TITLE
Import button disabled when no file chosen

### DIFF
--- a/index.html
+++ b/index.html
@@ -53,7 +53,7 @@
               <input name="log_url" type="url" id="log_url" ng-model="upload.logUrl" placeholder="URL" ng-disabled="busy || upload.logSrc != 'url'"/>
               <br><br>
             <input name="run" type="text" ng-model="upload.runName" required ng-disabled="busy" placeholder="Run name">
-            <button ng-click="fetchLog()" ng-disabled="busy || (upload.logSrc == 'file' && isFileEmpty) || (upload.logSrc == 'url' && !upload.logUrl) || !upload.runName  || !fileEvent.target.value" for="fileInput">Import Log</button>
+            <button ng-click="fetchLog()" ng-disabled="busy || (upload.logSrc == 'file' && isFileEmpty) || (upload.logSrc == 'url' && !upload.logUrl) || !upload.runName  || (!fileEvent.target.value && upload.logSrc == 'file')" for="fileInput">Import Log</button>
           </form>
         </div>
       </div>


### PR DESCRIPTION
I made a terrible mistake in my previous fix. That checked for target field to be non-empty even when the user wanted to import from URL. This should fix it. Apologies. @martiansideofthemoon

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/wptview/125)

<!-- Reviewable:end -->
