### PR TITLE
Clears upload file target after import

### DIFF
--- a/angular_scripts.js
+++ b/angular_scripts.js
@@ -339,6 +339,8 @@ app.controller('wptviewController', function($scope, $location, $interval, Resul
     .then(() => {
       $scope.isFileEmpty = true;
       $scope.upload.runName = "";
+      // Clears target for "Upload File" after import is complete.
+      $scope.fileEvent.target.value = null;
       $scope.busy = false;
       $scope.$apply();
     });


### PR DESCRIPTION
Importing a file and then clearing it does not allow importing the already selected file again. This fixes that issue by clearing target for "Upload File" after import is made from a file. @martiansideofthemoon

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/wptview/126)

<!-- Reviewable:end -->
