### PR TITLE
Prevent upload with duplicate run_name

### DIFF
--- a/angular_scripts.js
+++ b/angular_scripts.js
@@ -324,7 +324,16 @@ app.controller('wptviewController', function($scope, $location, $interval, Resul
 
   $scope.fetchLog = function () {
     if ($scope.upload.logSrc === 'file') {
-      $scope.uploadFile();
+      var run_names = [];
+      $scope.runs.forEach((run) => {
+        run_names.push(run.name);
+      });
+      //Check if run having same run_name exists
+      if ( run_names.indexOf($scope.upload.runName) !== -1 ) {
+        console.log("A run with name ",$scope.upload.runName," already exists.");
+      } else {
+        $scope.uploadFile();
+      }
     } else if ($scope.upload.logSrc === 'url') {
       $scope.fetchFromUrl();
     }


### PR DESCRIPTION
This checks through all runs to prevent upload of a log with an existing run name. In reference to issue #81. @martiansideofthemoon Have a look.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/wptview/132)

<!-- Reviewable:end -->
