### PR TITLE
Display no of results for given filter

### DIFF
--- a/angular_scripts.js
+++ b/angular_scripts.js
@@ -473,12 +473,17 @@ app.controller('wptviewController', function($scope, $location, $interval, Resul
     var maxTestId = null;
 
     $scope.busy = true;
-
+    console.log("filltable");
     if (page === "next") {
       var minTestId = $scope.resultsView.maxTestId;
     } else if (page === "prev") {
       var maxTestId = $scope.resultsView.minTestId;
     }
+
+    resultsModel.getResults($scope.filter, $scope.runs, minTestId, maxTestId, Infinity)
+      .then((results) => {
+        console.log("Total="+results.length);
+      });
 
     resultsModel.getResults($scope.filter, $scope.runs, minTestId, maxTestId, $scope.resultsView.limit)
       .then((results) => {


### PR DESCRIPTION
This is in reference to #45. As of now I am just logging the Total number of results in the console everytime the "Load" button or the `fillTable()` function is called. Is this approach alright or should I create a function similar to resultsModel.getResults()? @martiansideofthemoon @jgraham 

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/wptview/137)

<!-- Reviewable:end -->
